### PR TITLE
Fix sending undefined on employees with no job title

### DIFF
--- a/src/bamboohr.coffee
+++ b/src/bamboohr.coffee
@@ -171,8 +171,10 @@ module.exports = (robot) ->
             if employee.fields.photoUrl
               msg.send employee.fields.photoUrl
 
+            result = ''
+
             if employee.fields.jobTitle
-              result = "*Job Title:* #{employee.fields.jobTitle}\n"
+              result += "*Job Title:* #{employee.fields.jobTitle}\n"
 
             if employee.fields.workPhone
               result += "*Work Phone:* #{employee.fields.workPhone}\n"

--- a/src/bamboohr.coffee
+++ b/src/bamboohr.coffee
@@ -171,6 +171,8 @@ module.exports = (robot) ->
             if employee.fields.photoUrl
               msg.send employee.fields.photoUrl
 
+            msg.send "https://#{bamboohr_domain}.bamboohr.co.uk/employees/employee.php/?id=#{employee.id}"
+
             result = ''
 
             if employee.fields.jobTitle

--- a/test/bamboohr-test.coffee
+++ b/test/bamboohr-test.coffee
@@ -1,10 +1,13 @@
 chai = require 'chai'
 sinon = require 'sinon'
 chai.use require 'sinon-chai'
-
+bamboo = require 'node-bamboohr'
 expect = chai.expect
 
 describe 'bamboohr', ->
+  before ->
+    @employeesStub = sinon.stub(bamboo.prototype, 'employees')
+
   beforeEach ->
     @robot =
       respond: sinon.spy()
@@ -12,8 +15,28 @@ describe 'bamboohr', ->
 
     require('../src/bamboohr')(@robot)
 
+  afterEach ->
+    @employeesStub.reset()
+
   it 'registers a respond listener for "bamboo"', ->
     expect(@robot.respond).to.have.been.calledWith(/bamboo\s([\w\s]+)$/i)
+
+  it "when there's no fields for the employee it doesn't send undefined", ->
+    [regex, fn] = @robot.respond.args[0]
+    send = sinon.spy()
+
+    @employeesStub.yields(null, [{
+      fields: {
+        displayName: 'Farid'
+      }
+    }])
+
+    fn({
+      match: 'Bamboo Farid'.match(regex)
+      send
+    })
+
+    expect(send.calledWith(undefined)).to.be.false
 
   it 'registers a respond listener for "whosoff"', ->
     expect(@robot.respond).to.have.been.calledWith(/whos(out|off)(\stoday|\stomorrow|\sthis\sweek|\sthis\smonth|\snext\sweek|\snext\smonth)?$/i)


### PR DESCRIPTION
When an employee has no job title saved in bamboo HR, undefined will be shown in the message. This PR fixes the problem.

Here's an example:

![image](https://user-images.githubusercontent.com/822510/28752990-37a06c68-752c-11e7-8373-31b2d8911206.png)
